### PR TITLE
fixing typo pointed out by sales engineer

### DIFF
--- a/shared-content/configuration/system-components-configuration.md
+++ b/shared-content/configuration/system-components-configuration.md
@@ -31,7 +31,7 @@ Complete the following steps to configure system components. Use the `PUT` metho
 6. Enter the following cURL command (which uses the `PUT` method) to initialize the system components configuration.
 
     ```bash
-    curl -d "@ConfigureComponents.json" -H "Content-Type: application/json" -X PUT "http://localhost:5590/api/v1/configuration/system/components/<componentId>"
+    curl -d "@ConfigureComponents.json" -H "Content-Type: application/json" -X PUT "http://localhost:5590/api/v1/configuration/system/components"
     ```
 
     **Notes:**


### PR DESCRIPTION
I got an email from a sales engineer pointing out that <componentId> shouldn't be at the end of the endpoint in the curl command. We should apply this patch to all versions of the framework. I'm going to open multiple pull requests.