### PR TITLE
updated diagnostics and metadata config

### DIFF
--- a/shared-content/configuration/diagnostics-and-metadata.md
+++ b/shared-content/configuration/diagnostics-and-metadata.md
@@ -11,7 +11,7 @@ For more information about available metadata and what metadata are sent per met
 ## Configure general
 
 1. Start any of the [Configuration tools](xref:ConfigurationTools) capable of making HTTP requests.
-2. Run a `PUT` command to the following endpoint, setting `enableDiagnostics` to either `true` or `false`, `MetadataLevel` to `None`, `Low`, `Medium`, or `High` and `HealthPrefix` to a `string` or `null`: `http://localhost:5590/api/v1/configuration/system/general`
+2. Run a `PUT` command to the following endpoint, setting `enableDiagnostics` to either `true` or `false`, `MetadataLevel` to `None`, `Low`, `Medium`, or `High` and `HealthPrefix` to a string or `null`: `http://localhost:5590/api/v1/configuration/system/general`
 
    **Note:** `5590` is the default port number. If you selected a different port number, replace it with that value.
 
@@ -36,8 +36,8 @@ The following parameters are available for configuring general:
 | Parameter             | Required | Type    | Description |
 | ---------             | -------- | ------- | ----------- |
 | **EnableDiagnostics** | Optional | `boolean` | Determines if diagnostics are enabled<br><br>Allowed value: `true` or `false`<br>Default value: `true`<br>|
-| **MetadataLevel** | Optional | `reference` | Defines amount of metadata sent to OMF endpoints.<br><br> Allowed value: `None`, `Low`, `Medium`, and `High`<br> Default value: `Medium` <br>|
-| **HealthPrefix** | Optional | `reference` | [Optional] Prefix to use for health and diagnostics stream and asset IDs.<br> Default value: `null`|
+| **MetadataLevel** | Optional | `reference` | Defines amount of metadata sent to OMF endpoints.<br><br> Allowed value: `None`, `Low`, `Medium`, and `High`<br> Default value: `Medium`|
+| **HealthPrefix** | Optional | `reference` | Prefix to use for health and diagnostics stream and asset IDs.<br> Default value: `null`|
 
 ## Example
 

--- a/shared-content/configuration/diagnostics-and-metadata.md
+++ b/shared-content/configuration/diagnostics-and-metadata.md
@@ -11,14 +11,14 @@ For more information about available metadata and what metadata are sent per met
 ## Configure general
 
 1. Start any of the [Configuration tools](xref:ConfigurationTools) capable of making HTTP requests.
-2. Run a `PUT` command to the following endpoint, setting `enableDiagnostics` to either `true` or `false` and `MetadataLevel` to `None`, `Low`, `Medium`, or `High`: `http://localhost:5590/api/v1/configuration/system/general`
+2. Run a `PUT` command to the following endpoint, setting `enableDiagnostics` to either `true` or `false`, `MetadataLevel` to `None`, `Low`, `Medium`, or `High` and `HealthPrefix` to a `string` or `null`: `http://localhost:5590/api/v1/configuration/system/general`
 
    **Note:** `5590` is the default port number. If you selected a different port number, replace it with that value.
 
    Example using `curl`:
 
    ```bash
-   curl -d "{ \"enableDiagnostics\":true, \"enableMetadata\":false }" -X PUT "http://localhost:5590/api/v1/configuration/system/general"
+   curl -d "{ \"enableDiagnostics\":true, \"enableMetadata\":false, \"HealthPrefix\":\"Machine1\" }" -X PUT "http://localhost:5590/api/v1/configuration/system/general"
    ```
 
 ## General schema
@@ -36,7 +36,8 @@ The following parameters are available for configuring general:
 | Parameter             | Required | Type    | Description |
 | ---------             | -------- | ------- | ----------- |
 | **EnableDiagnostics** | Optional | `boolean` | Determines if diagnostics are enabled<br><br>Allowed value: `true` or `false`<br>Default value: `true`<br>|
-| **MetadataLevel** | Optional | `reference` | Defines amount of metadata sent to OMF endpoints.<br><br> Allowed value: `None`, `Low`, `Medium`, and `High`<br> Default value: `Medium` |
+| **MetadataLevel** | Optional | `reference` | Defines amount of metadata sent to OMF endpoints.<br><br> Allowed value: `None`, `Low`, `Medium`, and `High`<br> Default value: `Medium` <br>|
+| **HealthPrefix** | Optional | `reference` | [Optional] Prefix to use for health and diagnostics stream and asset IDs.<br> Default value: `null`|
 
 ## Example
 
@@ -53,7 +54,8 @@ Sample output:
 ```code
 {
   "EnableDiagnostics": true,
-  "MetadataLevel": "Medium"
+  "MetadataLevel": "Medium",
+  "HealthPrefix": "Machine1"
 }
 ```
 


### PR DESCRIPTION
GeneralConfig now contains a new field called "HealthPrefix" which will prefix all health and diagnostics streams with the healthprefix

https://dev.azure.com/osieng/engineering/_workitems/edit/224556/