### PR TITLE
291230 configuration updates for shared PI Adapter Schedules topic

### DIFF
--- a/shared-content/configuration/schedules.md
+++ b/shared-content/configuration/schedules.md
@@ -51,8 +51,8 @@ The following parameters are available for configuring schedules:
 | Parameter                | Required | Type      | Description |
 | ------------------------ | -------- | --------- | ----------- |
 |**Id**              | Required | `string` | Unique identifier for the schedule<br><br>Allowed value: any string identifier |
-|**Period** | Required | `string` | The data sampling rate of the schedule. The expected format is HH:MM:SS.###. <br><br>Invalid input: `null`, negative timespan, zero <br> Default value: `null` (must be specified)|
-|**Offset**     | Optional | `string` | The offset from the midnight when the schedule starts. The expected format is HH:MM:SS.### <br><br>Invalid input: negative timespan<br>Default value: `null`|
+|**Period** | Required | `string` | The data sampling rate of the schedule. The expected format is HH:MM:SS.###. <br><br>Invalid inputs: `null`, negative timespan, or zero <br><br>A default value must be specified.|
+|**Offset**     | Optional | `string` | The offset from the midnight when the schedule starts. The expected format is HH:MM:SS.### <br><br>Invalid input: negative timespan<br><br>A default value must specified. |
 
 **Note:** You can also specify timespans as numbers in seconds. For example, `"Period": 25` specifies 25 seconds, or `"Period": 125` specifies 2 minutes and 5 seconds.
 


### PR DESCRIPTION
Per feedback in 291230:

![image](https://user-images.githubusercontent.com/59098013/154424961-a6fbea02-bafa-4a60-b732-ce33fb13e939.png)

This affects the shared PI Adapter Schedules topic for the **Period** and **Offset** parameters. Cleaned up minor text as well for this update. :)

Note that this shared topic will be merged for the following PI Adapters that features the Schedules topic per 291230 once this PR is approved:

- PI Adapter for BACnet
- PI Adapter for DNP3
- PI Adapter for Modbus TCP
- PI Adapter for RDBMS