### PR TITLE
failover health and diagnostics additions

### DIFF
--- a/shared-content/configuration/client-failover.md
+++ b/shared-content/configuration/client-failover.md
@@ -95,6 +95,9 @@ The following is an example of failover state returned from the adapter:
     "AdapterState": "Running"
 }
 ```
+## Health
+
+If the adapter has health endpoints configured, the client failover configuration values `Mode` and `FailoverGroupId` will be included in the static failover health data.
 
 ## REST URLs
 

--- a/shared-content/diagnostics/diagnostics.md
+++ b/shared-content/diagnostics/diagnostics.md
@@ -18,3 +18,7 @@ The following diagnostics data are available:
 - [Stream count](xref:StreamCount)
 - [IO rate](xref:IORate)
 - [Error rate](xref:ErrorRate)
+
+Additionally, if the adapter supports failover, the following data is available:
+
+- [Failover Status](xref:FailoverStatus)

--- a/shared-content/diagnostics/failover-status.md
+++ b/shared-content/diagnostics/failover-status.md
@@ -9,5 +9,5 @@ The `Diagnostics.Failover.FailoverStatus` dynamic type includes the following va
 | Property  | Type   | Description                                            |
 | --------- | ------ | -------------------------------------------------------|
 | **timestamp** | `string` | Timestamp of event                                    |
-| **FailoverStatus**  | `float` | Value between 0 and 100 indicating the adapter's overall connectivity to each data source. 100 is 'Good' and all data source connections were successful. 0 is 'Bad' and no data is being collected.|
-| **FailoverRole**  | `string` | Current role of the failover instance. When the adapter assumes `Primary` role it is egressing data. In the `Secondary` role, the adapter will not be egressing data to the failover endpoint, but may retain a cacha of data if the failover mode is `Hot`.|
+| **FailoverStatus**  | `float` | Value between 0 and 100 indicating the adapter's overall connectivity to each data source. 100 is 'Good' and all data source connections are successful. 0 is 'Bad' and no data is being collected.|
+| **FailoverRole**  | `string` | Current role of the failover instance. When the adapter assumes the `Primary` role, it is egressing data. If the adapter is set to the `Secondary` role, it does not egress data to the failover endpoint, but it may retain a cache of data if the failover mode is set to `Hot`.|

--- a/shared-content/diagnostics/failover-status.md
+++ b/shared-content/diagnostics/failover-status.md
@@ -1,0 +1,13 @@
+---
+uid: FailoverStatus
+---
+
+# Failover Status
+
+The `Diagnostics.Failover.FailoverStatus` dynamic type includes the following values, which are logged in a stream with the `Id` `Failover.FailoverStatus`. This diagnostic stream contains system level information related to the failover status of the adapter.
+
+| Property  | Type   | Description                                            |
+| --------- | ------ | -------------------------------------------------------|
+| **timestamp** | `string` | Timestamp of event                                    |
+| **FailoverStatus**  | `float` | . Value between 0 and 100 indicating the adapter's overall connectivity to each data source. 100 is 'Good' and all data source connections were successful. 0 is 'Bad' and no data is being collected.|
+| **FailoverRole**  | `string` | Current role of the failover instance. When the adapter assumes `Primary` role it is egressing data. In the `Secondary` role, the adapter will not be egressing data to the failover endpoint, but may retain a cacha of data if the failover mode is `Hot`.|

--- a/shared-content/diagnostics/failover-status.md
+++ b/shared-content/diagnostics/failover-status.md
@@ -9,5 +9,5 @@ The `Diagnostics.Failover.FailoverStatus` dynamic type includes the following va
 | Property  | Type   | Description                                            |
 | --------- | ------ | -------------------------------------------------------|
 | **timestamp** | `string` | Timestamp of event                                    |
-| **FailoverStatus**  | `float` | . Value between 0 and 100 indicating the adapter's overall connectivity to each data source. 100 is 'Good' and all data source connections were successful. 0 is 'Bad' and no data is being collected.|
+| **FailoverStatus**  | `float` | Value between 0 and 100 indicating the adapter's overall connectivity to each data source. 100 is 'Good' and all data source connections were successful. 0 is 'Bad' and no data is being collected.|
 | **FailoverRole**  | `string` | Current role of the failover instance. When the adapter assumes `Primary` role it is egressing data. In the `Secondary` role, the adapter will not be egressing data to the failover endpoint, but may retain a cacha of data if the failover mode is `Hot`.|


### PR DESCRIPTION
Failover health updates from WI 231700. 
Also we might consider updating the example picture for AF structure in health-and-diagnostics.md to include a failover health asset. What do you think? Example below

![image](https://user-images.githubusercontent.com/43865349/165124640-87408a6c-fe8f-49d4-9c5d-6620fc604bef.png)
