### PR TITLE
Added description of behavior changes in automatic history recovery when client failover is enabled 

### DIFF
--- a/shared-content/configuration/history-recovery/automatic-history-recovery.md
+++ b/shared-content/configuration/history-recovery/automatic-history-recovery.md
@@ -18,7 +18,8 @@ Automatic history intervals cannot be longer than four days. If an interval is l
 
 For adapters that support client failover, the automatic history recovery behavior is affected by whether or not you configure client failover for the running adapter instance. See [Client failover configuration](../client-failover.md) for configuring cilent failover on supported adapters. 
 - When client failover is disabled, the automatic history recovery works as described in [Automatic history recovery](#automatic-history-recovery) without any behavior changes.
-- When client failover is enabled, the automatic history recovery behave differently, as listed below.
-  - The tracking of **DeviceStatus**, creation of history recovery intervals and automatic data backfill only occur when the adapter is in `Primary` role. 
-  - The adapter does not track `Shutdown` of the adatper to create a new history recovery interval.
-  - The adapter with failover role changed from `Primary` to `Secondary` stops tracking all open intervals and close them all.
+- When client failover is enabled, automatic history recovery is affected as listed below.
+  - The tracking of **DeviceStatus**, creation of history recovery intervals, and automatic data backfill only occur when the adapter is in the `Primary` role. 
+  - The adapter does not track the `Shutdown` status of the adapter to create a new history recovery interval.
+  - The adapter, with its failover role changed from `Primary` to `Secondary`, stops tracking all open intervals and closes them all.
+  - The adapter attempts to recover data for existing intervals only in the `Primary` role.

--- a/shared-content/configuration/history-recovery/automatic-history-recovery.md
+++ b/shared-content/configuration/history-recovery/automatic-history-recovery.md
@@ -13,3 +13,12 @@ For automatic history recovery, the adapter tracks changes to the **DeviceStatus
 ## History recovery intervals
 
 Automatic history intervals cannot be longer than four days. If an interval is longer than four days, the adapter automatically changes the start time of the interval to be no earlier than four days before the end time prior to starting a recovery. If a current outage lasts longer than four days, when the device status finally improves the adapter recovers up to four days before the current time. This avoids introducing additional data gaps.
+
+## Behavior changes with client failover enabled
+
+For adapters that support client failover, the automatic history recovery behavior is affected by whether or not you configure client failover for the running adapter instance. See [Client failover configuration](../client-failover.md) for configuring cilent failover on supported adapters. 
+- When client failover is disabled, the automatic history recovery works as described in [Automatic history recovery](#automatic-history-recovery) without any behavvior changes.
+- When client failover is enabled, the automatic history recovery behave differently, as listed below.
+  - The tracking of **DeviceStatus**, creation of history recovery intervals and automatic data backfill only occur when the adapter is in `Primary` role. 
+  - The adapter does not track `Shutdown` of the adatper to create a new history recovery interval.
+  - The adapter with failover role changed from `Primary` to `Secondary` stops tracking all open intervals and close them all.

--- a/shared-content/configuration/history-recovery/automatic-history-recovery.md
+++ b/shared-content/configuration/history-recovery/automatic-history-recovery.md
@@ -17,7 +17,7 @@ Automatic history intervals cannot be longer than four days. If an interval is l
 ## Behavior changes with client failover enabled
 
 For adapters that support client failover, the automatic history recovery behavior is affected by whether or not you configure client failover for the running adapter instance. See [Client failover configuration](../client-failover.md) for configuring cilent failover on supported adapters. 
-- When client failover is disabled, the automatic history recovery works as described in [Automatic history recovery](#automatic-history-recovery) without any behavvior changes.
+- When client failover is disabled, the automatic history recovery works as described in [Automatic history recovery](#automatic-history-recovery) without any behavior changes.
 - When client failover is enabled, the automatic history recovery behave differently, as listed below.
   - The tracking of **DeviceStatus**, creation of history recovery intervals and automatic data backfill only occur when the adapter is in `Primary` role. 
   - The adapter does not track `Shutdown` of the adatper to create a new history recovery interval.


### PR DESCRIPTION
Hi Team,

This PR added a session in the automatic history recovery page to describe the behavior changes when client failover is enabled in  supported adapters.
